### PR TITLE
ingress: fix api port in ingress with bridge network demo

### DIFF
--- a/ingress-gateway/ig-bridge-demo.nomad
+++ b/ingress-gateway/ig-bridge-demo.nomad
@@ -73,7 +73,7 @@ job "ig-bridge-demo" {
 
     service {
       name = "uuid-api"
-      port = "${NOMAD_PORT_api}"
+      port = "api"
 
       connect {
         native = true


### PR DESCRIPTION
Use port label rather than interpolated value, which stopped
working after 60838c94f83b5